### PR TITLE
Link to deploy docs in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+Airbrake deployment
+========
+We use ansible to deploy slate. :cow: :speech_balloon: Please use the
+[Deploy slate](https://github.com/airbrake/ansible/wiki/Deploy-slate) ansible
+doc.
+
 Slate
 ========
 


### PR DESCRIPTION
Provide a link to the [Deploy slate](https://github.com/airbrake/ansible/wiki/Deploy-slate) ansible wiki doc.