### PR TITLE
Fix group params typo

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -564,7 +564,7 @@ action | | Filters groups by action.
 archived | | When set to `true` returns archived groups.
 muted | | When set to `true` returns muted groups.
 start_time | | Returns groups created after `start_time`.
-end_time | | Returns groups created before `ned_time`.
+end_time | | Returns groups created before `end_time`.
 order | last_notice | Sorts groups by `last_notice`, `notice_count`, `weight` and `created` fields.
 
 ### Response


### PR DESCRIPTION
Change ned_time to end_time in [List groups/query params](https://airbrake.io/docs/#list-groups-v4)

### Screenshot
![screen shot 2016-04-06 at 2 30 53 pm](https://cloud.githubusercontent.com/assets/2172513/14333649/b164fb1a-fc04-11e5-9fce-3a178e8fcab2.png)
