### PR TITLE
Update to correct version of API for projects

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -369,7 +369,7 @@ return a `413 Request Entity Too Large` status.
 ## List projects v4
 
 ```shell
-curl "https://airbrake.io/api/v3/projects?key=USER_KEY"
+curl "https://airbrake.io/api/v4/projects?key=USER_KEY"
 ```
 
 ```json
@@ -393,7 +393,7 @@ curl "https://airbrake.io/api/v3/projects?key=USER_KEY"
 
 ### HTTP request
 
-`GET https://airbrake.io/api/v3/projects?key=USER_KEY`
+`GET https://airbrake.io/api/v4/projects?key=USER_KEY`
 
 ### Response
 
@@ -402,7 +402,7 @@ The API returns `200 OK` status code on success.
 ## Show project v4
 
 ```shell
-curl "https://airbrake.io/api/v3/projects/PROJECT_ID?key=USER_KEY"
+curl "https://airbrake.io/api/v4/projects/PROJECT_ID?key=USER_KEY"
 ```
 
 ```json
@@ -424,7 +424,7 @@ curl "https://airbrake.io/api/v3/projects/PROJECT_ID?key=USER_KEY"
 
 ### HTTP request
 
-`GET https://airbrake.io/api/v3/projects/PROJECT_ID?key=USER_KEY`
+`GET https://airbrake.io/api/v4/projects/PROJECT_ID?key=USER_KEY`
 
 ### Response
 


### PR DESCRIPTION
v4 of our API is actually used for these project endpoints. This updates the docs to show that. Using v3 will return a `404`.