### PR TITLE
Add rate limit note about status returned

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -367,6 +367,9 @@ for processing. Use the `url` or `id` in the response to query the status of an
 error. This will tell you if the error has been processed, or if it has been
 rejected for reasons including invalid JSON and rate limiting.
 
+If errors are sent in excess of the account's rate limit, the API will return a
+`420 Too many requests in last minute - account is rate limited` status.
+
 If the request body size exceeds **64KB**, the API will reject the notice and
 return a `413 Request Entity Too Large` status.
 


### PR DESCRIPTION
Closes https://github.com/airbrake/airbrake-docs/issues/184

Someone brought up that we don't say what people should expect from our API when being rate limited in our docs repo: https://github.com/airbrake/airbrake-docs/issues/184

This PR adds a note to our API docs to explain what they should expect from our API.
