### PR TITLE
Add note that explains notice/group terminology

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -585,7 +585,7 @@ The API returns `200 OK` status code.
 # Groups v4
 
 > **Note:**
-> Groups are also known as "error groups" in the web app UI.
+> Groups are also known as "errors" in the web app.
 
 ## List groups v4
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -584,8 +584,9 @@ The API returns `200 OK` status code.
 
 # Groups v4
 
-> **Note:**
-> Groups are also known as "errors" in the web app.
+<aside class="notice">
+Groups are also known as "errors" in the web app.
+</aside>
 
 ## List groups v4
 
@@ -834,8 +835,9 @@ The API returns `200 OK` status code on success.
 
 # Notices v4
 
-> **Note:**
-> Notices are also known as "occurrences" in the web app.
+<aside class="notice">
+Notices are also known as "occurrences" in the web app.
+</aside>
 
 ## List notices v4
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -584,6 +584,9 @@ The API returns `200 OK` status code.
 
 # Groups v4
 
+> **Note:**
+> Groups are also known as "error groups" in the web app UI.
+
 ## List groups v4
 
 The API returns list of groups. See [Pagination](#pagination) section for supported query parameters and response fields.
@@ -830,6 +833,9 @@ limit | 100 | Limits number of results.
 The API returns `200 OK` status code on success.
 
 # Notices v4
+
+> **Note:**
+> Notices are also known as "error occurrences" in the web app UI.
 
 ## List notices v4
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -835,7 +835,7 @@ The API returns `200 OK` status code on success.
 # Notices v4
 
 > **Note:**
-> Notices are also known as "error occurrences" in the web app UI.
+> Notices are also known as "occurrences" in the web app.
 
 ## List notices v4
 


### PR DESCRIPTION
To avoid user confusion, add a note that explains that "groups" are
called "error groups" and "notices" are called "error occurrences" in
the actual Airbrake UI. Notices and groups are terms used by the API.

## Screenshots of additions


![Screen Shot 2019-10-22 at 11 56 14 AM](https://user-images.githubusercontent.com/2172513/67320695-6ca40780-f4c3-11e9-93d9-752f12cb238d.png)
![Screen Shot 2019-10-22 at 11 56 02 AM](https://user-images.githubusercontent.com/2172513/67320703-6e6dcb00-f4c3-11e9-8235-59c394c33be0.png)
