### PR TITLE
Mention context/route

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -267,7 +267,9 @@ curl -X POST -H "Content-Type: application/json" -d JSON "https://airbrake.io/ap
       "id": "12345",
       "name": "root",
       "email": "root@root.com"
-    }
+    },
+
+    "route": "/pricing"
   },
   "environment": {
     "PORT": "443",
@@ -319,6 +321,7 @@ context/rootDirectory | false | The application's root directory path.
 context/user/id | false | If applicable, the current user's ID.
 context/user/name | false | If applicable, the current user's username.
 context/user/email | false | If applicable, the current user's email address.
+context/route | false | Application route that triggered this error.
 environment | false | An object containing the current environment variables. Where the key is the variable name, e.g. `{ "PORT": "443", "CODE_NAME": "gorilla" }`.
 session | false | An object containing the current session variables. Where the key is the variable name, e.g. `{ "basket_total": "1234", "user_id": "123" }`.
 params | false | An object containing the request parameters. Where the key is the parameter name, e.g. `{ "page": "3", "sort": "desc" }`.


### PR DESCRIPTION
`context/route` is displayed in Error Overview. When an account uses APM, the
route will be linkified. The link will lead to the APM dashboard.
