### PR TITLE
Fix curly bracket on breakdown json

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -238,7 +238,7 @@ curl -X PUT -H "Content-Type: application/json" \
             "sumsq": 160.0,
             "tdigest": "AAAAAkA0AAAAAAAAAAAAAUPSgAAB"
           }
-        {
+        }
       ]
     }
   ]


### PR DESCRIPTION
The payload has an open bracket when it should be a closed bracket
instead.

<img width="647" alt="Screen Shot 2021-03-11 at 4 17 42 PM" src="https://user-images.githubusercontent.com/2172513/110873104-dd4cef00-8285-11eb-925c-875a02c8141c.png">
