### PR TITLE
Fix json payload for breakdown

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -222,24 +222,20 @@ curl -X PUT -H "Content-Type: application/json" \
       "sumsq": 2500.0,
       "tdigest": "AAAAAkA0AAAAAAAAAAAAAUdqYAAB",
       "time": "2019-09-19T18:00:00+00:00",
-      "groups": [
-        {
-          "db": {
-            "count": 1,
-            "sum": 10.0,
-            "sumsq": 100.0,
-            "tdigest": "AAAAAkA0AAAAAAAAAAAAAUMDAAAB"
-          }
+      "groups": {
+        "db": {
+          "count": 1,
+          "sum": 10.0,
+          "sumsq": 100.0,
+          "tdigest": "AAAAAkA0AAAAAAAAAAAAAUMDAAAB"
         },
-        {
-          "view": {
-            "count": 1,
-            "sum": 40.0,
-            "sumsq": 160.0,
-            "tdigest": "AAAAAkA0AAAAAAAAAAAAAUPSgAAB"
-          }
+        "view": {
+          "count": 1,
+          "sum": 40.0,
+          "sumsq": 160.0,
+          "tdigest": "AAAAAkA0AAAAAAAAAAAAAUPSgAAB"
         }
-      ]
+      }
     }
   ]
 }'
@@ -257,12 +253,12 @@ routes/{i}/sum | true | Float | The route response time in milliseconds
 routes/{i}/sumsq | true | Float | The `sum` above squared
 routes/{i}/tdigest | true | String | The routes percentile info as a t-digest, [More info on t-digests](https://github.com/tdunning/t-digest)
 routes/{i}/time | true | String | The UTC time of the route activity to the minute, in [RFC3339 format](https://tools.ietf.org/html/rfc3339) `'2019-09-19T18:00:00+00:00'`
-routes/{i}/groups[] | true | Array | An array of group objects describing each pieces performance
-routes/{i}/groups{i}/label | true | Object | Object with a label e.g. `database`, `view`, `cache`, `http`, ...
-routes/{i}/groups{i}/label/count | true | Integer | The number of requests for this group
-routes/{i}/groups{i}/label/sum | true | Float | The response time in milliseconds for this group
-routes/{i}/groups{i}/label/sumsq | true | Float | The sum above squared
-routes/{i}/groups{i}/label/tdigest | true | String | The group's percentile info as a t-digest, [More info on t-digests](https://github.com/tdunning/t-digest)
+routes/{i}/groups | true | Object | An object describing individual pieces of performance
+routes/{i}/groups/label | true | Object | Object with a label e.g. `database`, `view`, `cache`, `http`, ...
+routes/{i}/groups/label/count | true | Integer | The number of requests for this group
+routes/{i}/groups/label/sum | true | Float | The response time in milliseconds for this group
+routes/{i}/groups/label/sumsq | true | Float | The sum above squared
+routes/{i}/groups/label/tdigest | true | String | The group's percentile info as a t-digest, [More info on t-digests](https://github.com/tdunning/t-digest)
 
 ### Responses
 


### PR DESCRIPTION
The performance breakdown does not require an array, a hash of the
different performance groups should be provided.


To test this, you can send this to a project. Just make sure to use a current enough time. eg: 
```
"time":"2021-03-12T01:23:40Z"
```

Here's an example curl:

```
curl -X PUT -H "Content-Type: application/json" \
"https://airbrake.io/api/v5/projects/ID/routes-breakdowns?key=KEY" \
-d '{
  "environment": "production",
  "routes": [
    {
      "route": "/boom",
      "method": "GET",
      "responseType": "json",
      "count": 1,
      "sum": 50.0,
      "sumsq": 2500.0,
      "tdigest": "AAAAAkAAAAAAAAAAAAAAAUJIAAAB",
      "time":"2021-03-12T01:23:40Z",
      "groups": {
        "db": {
            "count": 1,
            "sum": 10.0,
            "sumsq": 100.0,
            "tdigest": "AAAAAkAAAAAAAAAAAAAAAUEgAAAB"
        },
        "view": {
          "count": 1,
          "sum": 40.0,
          "sumsq": 160.0,
          "tdigest": "AAAAAkAAAAAAAAAAAAAAAUIgAAAB"
        }
      }
    }
  ]
}'
```

## Example showing up on the dashboard

<img width="884" alt="Screen Shot 2021-03-12 at 11 09 34 AM" src="https://user-images.githubusercontent.com/2172513/110987176-8eee2d80-8323-11eb-941e-1dc301136459.png">
