### PR TITLE
Add API docs for source maps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.0.1)
       addressable (~> 2)
-    ffi (1.9.17)
+    ffi (1.15.1)
     haml (4.0.7)
       tilt
     hamster (3.0.0)
@@ -119,4 +119,4 @@ DEPENDENCIES
   rouge (~> 2.0.5)
 
 BUNDLED WITH
-   1.14.3
+   1.17.3

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1252,6 +1252,91 @@ limit | 100 | Limits number of results.
 
 The API returns `200 OK` status code on success.
 
+# Source maps v4
+
+## Create source map v4
+
+```shell
+curl -X POST -F file=@app.min.js.map -F name="https://example.com/app.min.js.map" -F pattern="%/app.min.js" "https://api.airbrake.io/api/v4/projects/PROJECT_ID/sourcemaps?key=USER_KEY"
+```
+
+```json
+{
+  "id": "100"
+}
+```
+### HTTP request
+
+`POST https://api.airbrake.io/api/v4/projects/PROJECT_ID/sourcemaps?key=USER_KEY`
+
+### POST data
+
+Key | Description
+--- | -------
+file | Your source map file
+name | The location of your minified version of `app.js` that should be publicly available
+pattern | The optional pattern="%/app.min.js" is a SQL LIKE pattern and it tells Airbrake to apply the uploaded source map to all files that match the pattern. An underscore (`_`) in pattern stands for (matches) any single character; a percent sign (`%`) matches any sequence of zero or more characters
+
+### Response
+
+The API returns `201 Created` status code on success.
+
+## List source maps v4
+
+```shell
+curl "https://api.airbrake.io/api/v4/projects/PROJECT_ID/sourcemaps?key=USER_KEY"
+```
+
+```json
+{
+  "sourcemaps": [
+    {
+      "id": "100",
+      "projectId": 1,
+      "name": "https://example.com/app.min.js.map",
+      "pattern": "%/app.min.js",
+      "usedAt": "2021-05-28T08:20:48.57109Z"
+    }
+  ]
+}
+```
+
+### HTTP request
+
+`GET https://api.airbrake.io/api/v4/projects/PROJECT_ID/sourcemaps?key=USER_KEY`
+
+### Response
+
+The API returns `200 OK` status code on success.
+
+## Show source map v4
+
+```shell
+curl "https://api.airbrake.io/api/v4/projects/PROJECT_ID/sourcemaps/SOURCE_MAP_ID?key=USER_KEY"
+```
+
+### HTTP request
+
+`GET https://api.airbrake.io/api/v4/projects/PROJECT_ID/sourcemaps/SOURCE_MAP_ID?key=USER_KEY`
+
+### Response
+
+The API returns `200 OK` status code on success.
+
+## Delete source map v4
+
+The API permanently deletes source map.
+
+<aside class="warning">This operation can not be undone. Use it with care.</aside>
+
+```shell
+curl -X DELETE "https://api.airbrake.io/api/v4/projects/PROJECT_ID/sourcemaps/SOURCE_MAP_ID?key=USER_KEY"
+```
+
+### HTTP request
+
+`DELETE https://api.airbrake.io/api/v4/projects/PROJECT_ID/sourcemaps/SOURCE_MAP_ID?key=USER_KEY`
+
 # iOS crash reports v3
 
 ## Create iOS crash report v3


### PR DESCRIPTION
Closes airbrake/product#1956.

This adds API docs for source maps where we explain how to:
- Create (upload) the source map file
- List all source maps
- Fetch a specific source map
- Delete a specific source map

### Create source map
<img width="1786" alt="create-sm" src="https://user-images.githubusercontent.com/2136477/119982083-afdb2c00-bfbe-11eb-9a6e-9ab8d9010a70.png">

### List source maps
<img width="1808" alt="list-sm" src="https://user-images.githubusercontent.com/2136477/119982094-b1a4ef80-bfbe-11eb-9330-a090e00d220b.png">

### Show source map
<img width="1814" alt="show-sm" src="https://user-images.githubusercontent.com/2136477/119982102-b5387680-bfbe-11eb-8363-ee8150657339.png">

### Delete source map
<img width="1814" alt="delete-sm" src="https://user-images.githubusercontent.com/2136477/119982107-b669a380-bfbe-11eb-9053-c1701f9e34ce.png">
