### PR TITLE
Add count to source maps response

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1289,6 +1289,7 @@ curl "https://api.airbrake.io/api/v4/projects/PROJECT_ID/sourcemaps?key=USER_KEY
 
 ```json
 {
+  "count": 1,
   "sourcemaps": [
     {
       "id": "100",


### PR DESCRIPTION
Update API docs to reflect Goab update: airbrake/goab#2820

Adds this count to response example:

<img width="941" alt="Screen Shot 2021-07-13 at 8 24 41 AM" src="https://user-images.githubusercontent.com/2172513/125505417-7752bc51-38e3-45af-8e3e-cf68e983e300.png">
